### PR TITLE
Add doc for "Introduce `asakusafw.javac.processorOptions`"

### DIFF
--- a/docs/ja/source/application/gradle-plugin-reference.rst
+++ b/docs/ja/source/application/gradle-plugin-reference.rst
@@ -355,6 +355,14 @@ Javaコンパイラ関する規約プロパティは、 ``asakusafw`` ブロッ�
       - String
       - ``${project.buildDir}/generated-sources/annotations``
       - アノテーションプロセッサが生成するJavaソースの出力先
+    * - ``processorOption``
+      - Object
+      - アノテーションプロセッサによる生成処理に必要な最低限のもの
+      - アノテーションプロセッサに対するオプションを ``<key>, <value>`` の形式で指定する
+    * - ``processorOptions``
+      - Map<?, ?>
+      - アノテーションプロセッサによる生成処理に必要な最低限のもの
+      - アノテーションプロセッサに対するオプションをMap形式で指定する
     * - ``sourceEncoding``
       - String
       - ``UTF-8``


### PR DESCRIPTION
## Summary
This PR modifies documentation for "Introduce `asakusafw.javac.processorOptions`" ( asakusafw/asakusafw-sdk#115 ).

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
asakusafw/asakusafw-sdk#115

## Wanted reviewer
N/A.
