### PR TITLE
Change deployment archive filename on basic exmaples

### DIFF
--- a/docs/ja/source/introduction/start-guide.rst
+++ b/docs/ja/source/introduction/start-guide.rst
@@ -303,7 +303,7 @@ Shafuを導入した開発環境では、コンテキストメニューから :m
 * Asakusa DSLとデータモデル定義DSLから、HadoopやSparkなどの各処理系で実行可能なプログラム群を生成
 * アプリケーションを実行環境に配置するためのデプロイメントアーカイブファイルを生成
 
-デプロイメントアーカイブファイルはプロジェクトの :file:`build` ディレクトリ配下に ``example-basic-spark.tar.gz`` というファイル名で生成されます。
+デプロイメントアーカイブファイルはプロジェクトの :file:`build` ディレクトリ配下に ``asakusafw-example-basic-spark.tar.gz`` というファイル名で生成されます。
 
 .. _introduction-start-guide-deploy-app:
 
@@ -314,7 +314,7 @@ Shafuを導入した開発環境では、コンテキストメニューから :m
 
 通常、デプロイ対象となるノードはHadoopやSparkのクライアントモジュールがインストールされているノードを選択します。
 
-以降の手順を行う前に、デプロイメントアーカイブファイル ``example-basic-spark.tar.gz`` をデプロイ対象となるノードに転送しておいてください。
+以降の手順を行う前に、デプロイメントアーカイブファイル ``asakusafw-example-basic-spark.tar.gz`` をデプロイ対象となるノードに転送しておいてください。
 
 環境変数の設定
 ~~~~~~~~~~~~~~
@@ -336,14 +336,14 @@ Shafuを導入した開発環境では、コンテキストメニューから :m
 デプロイメントアーカイブの展開
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`サンプルアプリケーションのビルド`_ で作成したデプロイメントアーカイブファイル ``example-basic-spark.tar.gz`` を配置し、 ``$ASAKUSA_HOME`` 配下にデプロイメントアーカイブを展開します。
+`サンプルアプリケーションのビルド`_ で作成したデプロイメントアーカイブファイル ``asakusafw-example-basic-spark.tar.gz`` を配置し、 ``$ASAKUSA_HOME`` 配下にデプロイメントアーカイブを展開します。
 展開後、 ``$ASAKUSA_HOME`` 配下の :file:`*.sh` に実行権限を追加します。
 
 ..  code-block:: sh
 
     mkdir -p "$ASAKUSA_HOME"
     cd "$ASAKUSA_HOME"
-    tar -xzf /path/to/example-basic-spark.tar.gz
+    tar -xzf /path/to/asakusafw-example-basic-spark.tar.gz
     find "$ASAKUSA_HOME" -name "*.sh" | xargs chmod u+x
 
 サンプルデータの配置

--- a/docs/ja/source/sandbox/asakusa-on-emr.rst
+++ b/docs/ja/source/sandbox/asakusa-on-emr.rst
@@ -181,7 +181,7 @@ S3に対するファイルアップロードはAWS CLIからも実行するこ�
 
 ..  code-block:: sh
 
-    aws s3 cp build/example-basic-spark-emr.tar.gz s3://[mybucket]/asakusafw/
+    aws s3 cp build/asakusafw-example-basic-spark-emr.tar.gz s3://[mybucket]/asakusafw/
 
 S3上のファイルを表示し、正しくアップロードされたことを確認します。
 
@@ -397,7 +397,7 @@ EMRクラスターに対して処理を要求するには、コンソールやCL
       * 第1引数:  ``s3://asakusafw/emr/deploy-asakusa.sh``
       * 第2引数:  `デプロイメントアーカイブをS3に配置`_ で配置したデプロイメントアーカイブのS3パス
 
-        * 例: ``s3://[mybucket]/asakusafw/example-basic-spark.tar.gz``
+        * 例: ``s3://[mybucket]/asakusafw/asakusafw-example-basic-spark.tar.gz``
 
     :guilabel:`失敗時の動作`
       * ``次へ`` を選択
@@ -431,7 +431,7 @@ AWS CLI を使ったデプロイ例を以下に示します。
     ActionOnFailure=CONTINUE,\
     Jar=s3://elasticmapreduce/libs/script-runner/script-runner.jar,\
     Args=s3://asakusafw/emr/deploy-asakusa.sh,\
-    s3://[mybucket]/asakusafw/example-basic-spark.tar.gz
+    s3://[mybucket]/asakusafw/asakusafw-example-basic-spark.tar.gz
 
 ステップを登録すると、以下のようにステップIDが表示されます。
 ステップIDはステップの実行結果を確認する場合などで使用します。


### PR DESCRIPTION
## Summary
This PR changes default deployment archive filename on basic examples.

## Background, Problem or Goal of the patch
See: asakusafw/asakusafw-examples#40

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
* asakusafw/asakusafw-examples#40

## Wanted reviewer
N/A.