### PR TITLE
Remove duplicate and old description

### DIFF
--- a/docs/ja/source/m3bp/index.rst
+++ b/docs/ja/source/m3bp/index.rst
@@ -26,11 +26,9 @@
 ----------------
 
 * `asakusafw-compiler (GitHub)`_
-* `asakusafw-dag (GitHub)`_
 * `asakusafw-m3bp (GitHub)`_
 
 ..  _`asakusafw-compiler (GitHub)`: https://github.com/asakusafw/asakusafw-compiler
-..  _`asakusafw-dag (GitHub)`: https://github.com/asakusafw/asakusafw-dag
 ..  _`asakusafw-m3bp (GitHub)`: https://github.com/asakusafw/asakusafw-m3bp
 
 APIリファレンス

--- a/docs/ja/source/m3bp/user-guide.rst
+++ b/docs/ja/source/m3bp/user-guide.rst
@@ -98,34 +98,14 @@ Hadoopディストリビューション
 
   * HDFSを経由してWindGateの入出力を授受
 
-|M3BP_FEATURE|\ は、以下のHadoopディストリビューションと組み合わせた運用環境で動作を検証しています。
-
-..  list-table:: 動作検証プラットフォーム(Hadoopディストリビューション)
-    :widths: 3 3 3 3
-    :header-rows: 1
-
-    * - Distribution
-      - Version
-      - OS
-      - JDK
-    * - Hortonworks Data Platform
-      - 2.4 (Apache Hadoop 2.7.1)
-      - Red Hat Enterprise Linux 7.2
-      - Java SE Development Kit 8u74
-    * - MapR [#]_
-      - 5.1.0 (Apache Hadoop 2.7.0)
-      - CentOS 7.2
-      - Java SE Development Kit 8u74
-
 Hadoopとの連携方法は、 `Hadoopとの連携`_ を参照してください。
 
-..  [#] |M3BP_FEATURE| をMapRと連携して利用する場合において、バッチアプリケーションの起動時にデッドロックが発生しアプリケーションが実行されないことがある問題を確認しています。
-        この問題の回避方法について `Hadoopとの連携`_ に記載しています。
+|M3BP_FEATURE|\ が動作を検証しているHadoopディストリビューションは、
+:doc:`../product/target-platform` の「Hadoopディストリビューション」を参照してください。
 
-マイグレーション
-~~~~~~~~~~~~~~~~
-
-過去の |M3BP_FEATURE| バージョンを利用している開発環境、およびアプリケーションプロジェクトのバージョンアップ手順は、:doc:`../application/migration-guide` を参照してください。
+..  attention::
+    |M3BP_FEATURE| をMapRと連携して利用する場合において、バッチアプリケーションの起動時にデッドロックが発生しアプリケーションが実行されないことがある問題を確認しています。
+    この問題の回避方法について `Hadoopとの連携`_ に記載しています。
 
 制限事項
 --------
@@ -136,12 +116,6 @@ Hadoopとの連携方法は、 `Hadoopとの連携`_ を参照してください
 
   * 「input group is too large; please use larger addressing mode instead」という主旨のエラーログが表示されます
   * 詳しくは :ref:`最適化設定 <optimization_properties>` の「入出力バッファのアクセス方式 (``com.asakusafw.m3bp.buffer.access``)」を参照してください
-
-非対応機能
-----------
-
-|M3BP_FEATURE|\ は、Asakusa Framework の該当バージョンで非推奨となっている機能には対応していません。
-
 
 開発環境の構築
 ==============

--- a/docs/ja/source/spark/user-guide.rst
+++ b/docs/ja/source/spark/user-guide.rst
@@ -48,18 +48,12 @@ Asakusa DSL
 ..  note::
     Asakusa on Spark バージョン 0.3系およびそれ以前のバージョンでは、Direct I/Oの出力処理にMapReduceを利用するためMapReduceの実行環境が合わせて必要でした。
 
-    Asakusa on Spark バージョン 0.4.0 からはDirect I/Oの出力処理もSpark上で実行するようになったため、MapReduceの実行環境は必須ではなくなりました。
+    Asakusa on Spark バージョン 0.4.0 ( Asakusa Framework バージョン 0.9.0 ) からはDirect I/Oの出力処理もSpark上で実行するようになったため、MapReduceの実行環境は必須ではなくなりました。
 
 ..  _spark-target-platform:
 
 対応プラットフォーム
 ====================
-
-Hadoopディストリビューション
-----------------------------
-
-Asakusa on Sparkが動作を検証しているHadoopディストリビューションは、
-:doc:`../product/target-platform` の「Hadoopディストリビューション」を参照してください。
 
 Spark
 -----
@@ -76,45 +70,11 @@ Spark
 
 ..  _`Running Spark on YARN`: https://spark.apache.org/docs/latest/running-on-yarn.html
 
-マイグレーション
-~~~~~~~~~~~~~~~~
+Hadoopディストリビューション
+----------------------------
 
-過去のAsakusa on Sparkバージョンを利用している開発環境、およびアプリケーションプロジェクトのバージョンアップ手順は、 :doc:`../application/migration-guide` を参照してください。
-
-..  attention::
-    Asakusa on Spark 0.2.2 以前のバージョンからマイグレーションを行う場合、Asakusa Framework バージョン は 0.7系からのマイグレーションとなります。
-    このため、 :doc:`../application/migration-guide` の「バージョン 0.8.0 へのマイグレーション」に関する記述を必ず確認してください。
-
-非対応機能
-~~~~~~~~~~
-
-Asakusa on Sparkは、Asakusa Frameworkの該当バージョンで非推奨となっている機能には対応していません。
-
-リンク
-------
-
-各対応プラットフォームへのリンクです。
-
-..  list-table::
-    :widths: 3 7
-    :header-rows: 1
-
-    * - Product
-      - Link
-    * - Apache Spark
-      - http://spark.apache.org/
-    * - Hortonworks Data Platform
-      - http://hortonworks.com/hdp/
-    * - MapR
-      - http://www.mapr.com/
-    * - Amazon EMR
-      - http://aws.amazon.com/elasticmapreduce/
-    * - Microsoft Azure HDInsight
-      - https://azure.microsoft.com/services/hdinsight/
-    * - JDK (Java SE)
-      - http://www.oracle.com/technetwork/java/javase/index.html
-    * - Gradle
-      - http://www.gradle.org/
+Asakusa on Sparkが動作を検証しているHadoopディストリビューションは、
+:doc:`../product/target-platform` の「Hadoopディストリビューション」を参照してください。
 
 開発環境の構築
 ==============


### PR DESCRIPTION
## Summary
This PR revises documentation as follows:
* Remove duplicate description for merging Asakusa Core , Asakusa on Spark and Asakusa on M3BP documentation
* Remove unnecessary description for Asakusa 0.9.0

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
