### PR TITLE
Add a field modifier `final`

### DIFF
--- a/docs/ja/source/dsl/operators.rst
+++ b/docs/ja/source/dsl/operators.rst
@@ -1144,8 +1144,8 @@ Flow DSLからは次のように利用します。
 ..  code-block:: java
 
     // スレッド安全なので抽出結果のオブジェクトは再利用可能
-    private A a = new A();
-    private B b = new B();
+    private final A a = new A();
+    private final B b = new B();
 
     /**
      * レコードに含まれるそれぞれのフィールドを抽出し、出力する。


### PR DESCRIPTION
## Summary

Add modifiers `final` to the instance fields in the example of Convert operator.

## Background, Problem or Goal of the patch

The instance field in example of Convert used as returned instance has a modifier `final`.
On the other hand, the instance fields in example of Extract do not.
This may confuse readers.

## Design of the fix, or a new feature

N/A

## Related Issue, Pull Request or Code

N/A

## Wanted reviewer

N/A