### PR TITLE
Remove restriction for M3BP 2GB input group

### DIFF
--- a/docs/ja/source/m3bp/optimization.rst
+++ b/docs/ja/source/m3bp/optimization.rst
@@ -163,17 +163,6 @@
 
   既定値: ``nio`` (Java NIOを利用)
 
-  ..  attention::
-      現在の実装では、本設定に ``nio`` を指定した際に以下の状況でエラーになります。
-
-      * :doc:`演算子の性能特性 <../dsl/operators>` が ``CoGroup``, ``Join``, ``Fold`` のいずれかで、個々のグループのシリアライズ後の容量が2GBを超える場合
-      * :doc:`Direct I/O <../directio/index>` の出力で、個々のグループ(各ファイル)のシリアライズ後の容量が2GBを超える場合 (出力ファイル名のパターンにワイルドカードを指定している場合にはこの制約はありません)
-
-      このエラーが発生すると、「input group is too large; please use larger addressing mode instead」という主旨のログが表示されます。
-
-      本設定に ``unsafe`` を指定することで、このデータサイズの制限を解除できます。
-
-
 ``hadoop.<name>``
   指定の ``<name>`` を名前に持つHadoopの設定を追加します。
 

--- a/docs/ja/source/m3bp/user-guide.rst
+++ b/docs/ja/source/m3bp/user-guide.rst
@@ -107,16 +107,6 @@ Hadoopとの連携方法は、 `Hadoopとの連携`_ を参照してください
     |M3BP_FEATURE| をMapRと連携して利用する場合において、バッチアプリケーションの起動時にデッドロックが発生しアプリケーションが実行されないことがある問題を確認しています。
     この問題の回避方法について `Hadoopとの連携`_ に記載しています。
 
-制限事項
---------
-
-現在、\ |M3BP_FEATURE|\ には以下の制限があります。
-
-* 標準設定では、単一の入力グループが2GB以上になるとエラーが発生する
-
-  * 「input group is too large; please use larger addressing mode instead」という主旨のエラーログが表示されます
-  * 詳しくは :ref:`最適化設定 <optimization_properties>` の「入出力バッファのアクセス方式 (``com.asakusafw.m3bp.buffer.access``)」を参照してください
-
 開発環境の構築
 ==============
 


### PR DESCRIPTION
## Summary
This PR modifies documentation for "Enable to handle > 2GB input group" ( asakusafw/asakusafw-m3bp#108 ) .

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
asakusafw/asakusafw-m3bp#108