### PR TITLE
Add document for using yaess profile on m3bp and vanilla

### DIFF
--- a/docs/ja/source/m3bp/user-guide.rst
+++ b/docs/ja/source/m3bp/user-guide.rst
@@ -259,6 +259,13 @@ Hadoopとの連携
             }
         }
 
+..  tip::
+    バッチアプリケーション実行時の環境変数は、YAESSプロファイルで設定することも可能です。
+
+    \ |M3BP_FEATURE|\ を利用する場合、コマンドラインジョブのプロファイル ``command.m3bp`` が利用できます。 :file:`$ASAKUSA_HOME/yaess/conf/yaess.properties` に ``command.m3bp.env.HADOOP_CMD`` といったような設定を追加することで、YAESSから\ |M3BP_FEATURE|\ を実行する際に環境変数が設定されます。
+
+    YAESSのコマンドラインジョブの設定方法について詳しくは、 :doc:`../yaess/user-guide` - :ref:`yaess-profile-command-section` などを参照してください。
+
 アプリケーションの実行
 ======================
 

--- a/docs/ja/source/sandbox/asakusa-vanilla.rst
+++ b/docs/ja/source/sandbox/asakusa-vanilla.rst
@@ -594,6 +594,14 @@ Asakusa Vanilla実行用のJVMプロセスを起動するコマンドには ``ha
 
 環境変数 ``ASAKUSA_VANILLA_LAUNCHER`` は実行コマンドの先頭に任意のコマンド文字列を追加します。
 
+..  tip::
+    バッチアプリケーション実行時の環境変数は、YAESSプロファイルで設定することも可能です。
+
+    \ |M3BP_FEATURE|\ を利用する場合、コマンドラインジョブのプロファイル ``command.vanilla`` が利用できます。 :file:`$ASAKUSA_HOME/yaess/conf/yaess.properties` に ``command.vanilla.env.HADOOP_CMD`` といったような設定を追加することで、YAESSからAsakusa Vanillaを実行する際に環境変数が設定されます。
+
+    YAESSのコマンドラインジョブの設定方法について詳しくは、 :doc:`../yaess/user-guide` - :ref:`yaess-profile-command-section` などを参照してください。
+
+
 ログの設定
 ----------
 


### PR DESCRIPTION
## Summary
This PR adds documentation for using yaess profile on Asakusa on M3BP and Asakusa Vanilla

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
