### PR TITLE
Modify document for "Bump Hive version"

### DIFF
--- a/docs/ja/source/application/gradle-plugin-reference.rst
+++ b/docs/ja/source/application/gradle-plugin-reference.rst
@@ -732,7 +732,7 @@ Direct I/O Hiveの構成に関する規約プロパティは、 ``asakusafwOrgan
       - この値をtrueにすると Direct I/O Hive連携モジュール用の構成を行う
     * - ``libraries``
       - java.util.List
-      - ``org.apache.hive:hive-exec:1.1.1``
+      - ``org.apache.hive:hive-exec:1.2.2``
       - Directi I/O Hiveが実行時に使用するHiveライブラリ
 
 ..  [#] これらのプロパティは規約オブジェクト :asakusa-gradle-groovydoc:`com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.HiveConfiguration` が提供します。

--- a/docs/ja/source/directio/using-hive.rst
+++ b/docs/ja/source/directio/using-hive.rst
@@ -385,17 +385,17 @@ b) Hiveデータ型とカラムナフォーマットのデータ型とのマッ�
       - ``STRING``
       - * ``VARCHAR``
         * ``CHAR``
-      - ``VARCHAR`` はHive ``0.12`` 以降から利用可能、 ``CHAR`` はHive ``0.13`` 以降から利用可能
+      -
     * - ``DECIMAL``
       - ``DECIMAL``
       - * ``DECIMAL(精度とスケールの指定)``
         * ``STRING``
-      - 精度とスケールの指定はHive ``0.13`` 以降から利用可能
+      -
     * - ``DATE``
       - ``DATE``
       - * ``TIMESTAMP``
         * ``STRING``
-      - ``DATE`` はHive ``0.12`` 以降から利用可能
+      -
     * - ``DATETIME``
       - ``TIMESTAMP``
       - * ``STRING``
@@ -430,10 +430,8 @@ b) Hiveデータ型とカラムナフォーマットのデータ型とのマッ�
 Hiveのバージョンに関して
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Asakusa Framework バージョン |version| では、Direct I/O の Hive連携モジュールにはHiveのバージョン ``1.1.1`` を使用しています。
+Asakusa Framework バージョン |version| では、Direct I/O の Hive連携モジュールにはHiveのバージョン ``1.2.2`` を使用しています。
 実行環境のHiveとAsakusa Frameworkが利用するHiveのバージョンが異なる場合、データの互換性に対する注意が必要です。
-
-例えば実行環境のHiveバージョンが ``0.11`` の場合、Asakusa Frameworkが利用するHiveのバージョンではHiveの ``VARCHAR`` 型や ``CHAR`` 型を持つファイルを生成することができますが、生成したファイルを実行環境のHiveは取り扱うことができません。
 
 マッピング型変換機能
 ^^^^^^^^^^^^^^^^^^^^
@@ -510,10 +508,6 @@ Hiveデータ型とカラムナフォーマットのデータ型とのマッピ�
 
 * `LanguageManual ORC <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+ORC>`_
 * `Parquet <https://cwiki.apache.org/confluence/display/Hive/Parquet>`_
-
-..  attention::
-    Asakusa Framework バージョン |version| では、Direct I/OはHiveのバージョン ``1.1.1`` のライブラリを使用しています。
-    そのため、Parquetに関しては上記のHiveのドキュメントに記載がある通り、DATEデータ型がサポートされていないことに注意してください。
 
 カラムナフォーマットファイルから除外するプロパティ
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
This PR modifies documentation for "Bump Hive version" (asakusafw/asakusafw#773).
This PR also removes description for data format compatibility of old Hive version.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
