### PR TITLE
Fix old asakusa version output

### DIFF
--- a/docs/ja/source/cli/user-guide.rst
+++ b/docs/ja/source/cli/user-guide.rst
@@ -1080,6 +1080,7 @@ SLF4JのSimpleLogger [#]_ のシステムプロパティを環境変数 ``ASAKUS
 
     $ asakusa version -v
     0.10.0
-    ASAKUSA_HOME=/home/asakusa/asakusa_home
-    java.version=1.8.0_121
-    java.vendor=Oracle Corporation
+    ASAKUSA_HOME: /home/asakusa/asakusa
+    Hadoop: /usr/local/lib/hadoop/bin/hadoop
+    java.version: 1.8.0_121
+    java.vendor: Oracle Corporation


### PR DESCRIPTION
## Summary
This PR fixes documentation for old `asakusa version -v` output.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
