### PR TITLE
Bump Gradle Wrapper version for version 0.10.0

### DIFF
--- a/docs/ja/source/application/gradle-plugin.rst
+++ b/docs/ja/source/application/gradle-plugin.rst
@@ -141,7 +141,7 @@ Asakusa Gradle Pluginを使った標準的なアプリケーション開発環�
     * - :file:`gradlew.bat`
       - Gradleラッパーコマンド (Windows)
     * - :file:`.buildtools`
-      - Gradleラッパーライブラリ (Gradle Version: 3.4.1)
+      - Gradleラッパーライブラリ (Gradle Version: 4.3.1)
 
 アプリケーション開発者は :file:`src` ディレクトリ配下を編集することでアプリケーションを開発します。
 :file:`build` ディレクトリは :file:`src` ディレクトリ配下のファイルをビルドすることで生成される成果物が配置されます。


### PR DESCRIPTION
## Summary
This PR bumps up Gradle Wrapper version in Asakusa Gradle Plugin User Guide (follow-up #93).

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
