### PR TITLE
Fix to use items from iteritems  for python3

### DIFF
--- a/docs/ja/source/_exts/asakusafw/javadoclinks.py
+++ b/docs/ja/source/_exts/asakusafw/javadoclinks.py
@@ -53,7 +53,7 @@ def make_link_role(base_url, prefix):
     return role
 
 def setup_link_roles(app):
-    for name, (base_url, prefix) in app.config.javadoclinks.iteritems():
+    for name, (base_url, prefix) in app.config.javadoclinks.items():
         app.add_role(name, make_link_role(base_url, prefix))
 
 def setup(app):


### PR DESCRIPTION
## Summary
This PR fixes to work sphinx build on python3.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
