### PR TITLE
Fix version of 0.9 migration guide

### DIFF
--- a/docs/ja/source/application/gradle-plugin-v09-changes.rst
+++ b/docs/ja/source/application/gradle-plugin-v09-changes.rst
@@ -43,7 +43,7 @@ Asakusa Gradle Pluginを利用する場合、これまではアプリケーシ�
             maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
         }
         dependencies {
-            classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.3'
+            classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0'
         }
     }
 


### PR DESCRIPTION
## Summary
This PR fixes typo of build.gradle example in version 0.9 migration guide.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.