### PR TITLE
Fix Maven Central repository URL

### DIFF
--- a/docs/ja/source/application/gradle-plugin-reference.rst
+++ b/docs/ja/source/application/gradle-plugin-reference.rst
@@ -255,7 +255,7 @@ Batch Application Plugin は、以下のリポジトリをプロジェクトに�
 
     * - 名前/URL
       - 説明
-    * - ``https://repo.maven.apache.org/``
+    * - ``https://repo.maven.apache.org/maven2``
       - Mavenのセントラルリポジトリ
     * - ``https://asakusafw.s3.amazonaws.com/maven/releases``
       - Asakusa Frameworkのリリース用Mavenリポジトリ


### PR DESCRIPTION
## Summary
This PR just fixes maven central repository URL in plugin reference.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.